### PR TITLE
Potential fix for code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/sslchecker.py
+++ b/sslchecker.py
@@ -39,6 +39,7 @@ def validate_domain(domain):
 def check_certificate(domain, port=443):
     try:
         context = ssl.create_default_context()
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
         with socket.create_connection((domain, port)) as sock:
             with context.wrap_socket(sock, server_hostname=domain) as ssock:
                 cert = ssock.getpeercert()


### PR DESCRIPTION
Potential fix for [https://github.com/SilentGlasses/checkSSL/security/code-scanning/1](https://github.com/SilentGlasses/checkSSL/security/code-scanning/1)

To fix the issue, the SSL context created in the `check_certificate` function should explicitly disallow insecure versions of TLS (1.0 and 1.1) and all versions of SSL. This can be achieved by setting `context.minimum_version = ssl.TLSVersion.TLSv1_2` after creating the context. This attribute is available in Python 3.7 and later. Since the script uses Python 3 specific features (like f-strings), it's reasonable to assume Python 3.7+ is targeted. 

To implement the fix:
- In `sslchecker.py`, in the function `check_certificate`, right after `context = ssl.create_default_context()`, add `context.minimum_version = ssl.TLSVersion.TLSv1_2`.

No new imports are required, as `ssl.TLSVersion` is already available via the existing `import ssl`.

Only this change is needed, and only the code block near lines 39–45 need to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
